### PR TITLE
44122: Disable external organisation unit

### DIFF
--- a/config/optional/webform.webform.disable_organizational_unit.yml
+++ b/config/optional/webform.webform.disable_organizational_unit.yml
@@ -8,22 +8,22 @@ dependencies:
 third_party_settings:
   os2forms:
     os2forms_nemid:
-      webform_type: ''
+      webform_type: ""
       nemlogin_auto_redirect: 0
   webform_entity_print:
     template:
-      header: ''
-      footer: ''
-      css: ''
+      header: ""
+      footer: ""
+      css: ""
     export_types:
       pdf:
         enabled: true
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
       word_docx:
         enabled: false
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
 open: null
 close: null
 weight: 0
@@ -31,8 +31,8 @@ uid: 1
 template: false
 archive: false
 id: disable_organizational_unit
-title: 'Disable External Organizational Unit'
-description: 'Send a request for disabling an organizational unit and submit it for approval.'
+title: "Disable External Organizational Unit"
+description: "Send a request for disabling an organizational unit and submit it for approval."
 category: GIR
 elements: |
   enter_organizational_unit:
@@ -66,11 +66,12 @@ elements: |
         '#title': Name
         '#disabled': true
         '#readonly': true
+      end_date:
+        '#type': date
+        '#title': 'Termination date'
         '#required': true
-    end_date:
-      '#type': date
-      '#title': 'End date'
-      '#date_date_format': ''
+        '#default_value': today
+        '#date_date_format': ''
     approval_information:
       '#type': fieldset
       '#title': 'Approval Information'
@@ -90,32 +91,32 @@ elements: |
           include_anonymous: true
           filter:
             type: _none
-css: ''
-javascript: ''
+css: ""
+javascript: ""
 settings:
   ajax: false
   ajax_scroll_top: form
-  ajax_progress_type: ''
-  ajax_effect: ''
+  ajax_progress_type: ""
+  ajax_effect: ""
   ajax_speed: null
   page: true
-  page_submit_path: ''
-  page_confirm_path: ''
-  page_theme_name: ''
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
-  form_open_message: ''
-  form_close_message: ''
+  form_exception_message: ""
+  form_open_message: ""
+  form_close_message: ""
   form_previous_submissions: true
   form_confidential: false
-  form_confidential_message: ''
+  form_confidential_message: ""
   form_remote_addr: true
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
-  form_prepopulate_source_entity_type: ''
+  form_prepopulate_source_entity_type: ""
   form_reset: false
   form_disable_autocomplete: false
   form_novalidate: false
@@ -127,35 +128,35 @@ settings:
   form_autofocus: false
   form_details_toggle: false
   form_access_denied: default
-  form_access_denied_title: ''
-  form_access_denied_message: ''
-  form_access_denied_attributes: {  }
-  form_file_limit: ''
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
   share: false
   share_node: false
-  share_theme_name: ''
+  share_theme_name: ""
   share_title: true
-  share_page_body_attributes: {  }
-  submission_label: ''
+  share_page_body_attributes: {}
+  submission_label: ""
   submission_log: false
-  submission_views: {  }
-  submission_views_replace: {  }
-  submission_user_columns: {  }
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
   submission_user_duplicate: false
   submission_access_denied: default
-  submission_access_denied_title: ''
-  submission_access_denied_message: ''
-  submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_excluded_elements: {}
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
-  previous_submission_message: ''
-  previous_submissions_message: ''
+  previous_submission_message: ""
+  previous_submissions_message: ""
   autofill: false
-  autofill_message: ''
-  autofill_excluded_elements: {  }
+  autofill_message: ""
+  autofill_excluded_elements: {}
   wizard_progress_bar: true
   wizard_progress_pages: false
   wizard_progress_percentage: false
@@ -164,49 +165,49 @@ settings:
   wizard_auto_forward: true
   wizard_auto_forward_hide_next_button: false
   wizard_keyboard: true
-  wizard_start_label: ''
+  wizard_start_label: ""
   wizard_preview_link: false
   wizard_confirmation: true
-  wizard_confirmation_label: ''
-  wizard_track: ''
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
+  wizard_confirmation_label: ""
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
   wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
   preview: 0
-  preview_label: ''
-  preview_title: ''
-  preview_message: ''
-  preview_attributes: {  }
-  preview_excluded_elements: {  }
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
   draft: none
   draft_multiple: false
   draft_auto_save: false
-  draft_saved_message: ''
-  draft_loaded_message: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
   confirmation_type: page
-  confirmation_title: ''
-  confirmation_message: ''
-  confirmation_url: ''
-  confirmation_attributes: {  }
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_url: ""
+  confirmation_attributes: {}
   confirmation_back: true
-  confirmation_back_label: ''
-  confirmation_back_attributes: {  }
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
   confirmation_exclude_query: false
   confirmation_exclude_token: false
   confirmation_update: false
   limit_total: null
   limit_total_interval: null
-  limit_total_message: ''
+  limit_total_message: ""
   limit_total_unique: false
   limit_user: null
   limit_user_interval: null
-  limit_user_message: ''
+  limit_user_message: ""
   limit_user_unique: false
   entity_limit_total: null
   entity_limit_total_interval: null
@@ -226,65 +227,65 @@ access:
     roles:
       - anonymous
       - authenticated
-    users: {  }
-    permissions: {  }
+    users: {}
+    permissions: {}
   view_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   purge_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   view_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   administer:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   test:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   configuration:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
 handlers:
   spawn_maestro_workflow:
     id: maestro
-    label: 'Spawn Maestro Workflow'
-    notes: ''
+    label: "Spawn Maestro Workflow"
+    notes: ""
     handler_id: spawn_maestro_workflow
     status: true
-    conditions: {  }
+    conditions: {}
     weight: 0
     settings:
       maestro_template: disable_org_unit
-      maestro_message_success: ''
-      maestro_message_failure: ''
+      maestro_message_success: ""
+      maestro_message_failure: ""
   load_organization_unit:
     id: org_unit
-    label: 'Load Organization Unit'
-    notes: ''
+    label: "Load Organization Unit"
+    notes: ""
     handler_id: load_organization_unit
     status: true
     conditions:
@@ -294,6 +295,5 @@ handlers:
         ':input[name="name"]':
           empty: true
     weight: 0
-    settings: {  }
-variants: {  }
-variants: {  }
+    settings: {}
+variants: {}

--- a/os2forms_egir.module
+++ b/os2forms_egir.module
@@ -134,8 +134,6 @@ function os2forms_egir_gir_change_org_unit($processID, $queueID) {
   else {
     return FALSE;
   }
-  // Get config.
-  $config = new EGIRConfig();
 
   // Validity.
   $validity = ['from' => $start_date, 'to' => $end_date];
@@ -205,7 +203,54 @@ function os2forms_egir_gir_change_external($processID, $queueID) {
  * Disable org unit.
  */
 function os2forms_egir_gir_disable_org_unit($processID, $queueID) {
-  // @todo Implement this.
+  // Get ID for webform which spawned this process.
+  $sid = MaestroEngine::getEntityIdentiferByUniqueID($processID, 'submission');
+  if ($sid) {
+
+    $webform_submission = WebformSubmission::load($sid);
+    // cf.
+    // https://www.drupal.org/project/webform/issues/2911356#comment-12271553
+    $values = $webform_submission->getData();
+
+    // Termination data.
+    $name = $values['name'];
+    $org_unit_id = $values['organizational_unit'];
+    $end_date = $values['end_date'];
+  }
+  else {
+    return FALSE;
+  }
+
+  // We terminate *from* end_date *to* infinity.
+  // NB: This kind of validity payload is only possible as of MO ^2.0!
+  $validity = ['from' => $end_date, 'to' => NULL];
+  $org_unit_uuid = GIRUtils::getTermData($org_unit_id, 'field_uuid');
+
+  $termination_data = [
+    'type' => 'org_unit',
+    'uuid' => $org_unit_uuid,
+    'validity' => $validity,
+  ];
+
+  $json_data = json_encode($termination_data);
+  GIRUtils::formsLog()->notice('Termination data sent: <' . $json_data . '>');
+
+  $resp = GIRUtils::postJsonToApi('/service/details/terminate', $json_data);
+
+  if ($resp->getStatusCode() === 200) {
+    $url_status = 'Success';
+    $url_body = 'Organisation unit ' . $name
+              . ' was successfully terminated from ' . $end_date;
+  }
+  else {
+    $url_status = 'Failed';
+    $err_msg = json_decode($resp->getBody(), TRUE)['description'] ?? 'No description';
+    $url_body = 'Unable to terminate organisation unit ' . $name . ': ' . $err_msg;
+  };
+
+  MaestroEngine::setProcessVariable('url_status', $url_status, $processID);
+  MaestroEngine::setProcessVariable('url_body', $url_body, $processID);
+
   return TRUE;
 }
 

--- a/src/GIRUtils.php
+++ b/src/GIRUtils.php
@@ -3,10 +3,6 @@
 namespace Drupal\os2forms_egir;
 
 use GuzzleHttp\Exception\BadResponseException;
-use Dotenv\Dotenv;
-
-$dotenv = Dotenv::createImmutable(__DIR__);
-$dotenv->safeLoad();
 
 /**
  * Utilities for GIR communication & EGIR form data.


### PR DESCRIPTION
This PR adds the POST request necessary to terminate organisation units in GIR from EGIR. 

It has been tested by submitting the webform in my local test environment. Note that usage of `Dotenv` in `GIRUtils` has been removed as it is no longer necessary with our new development setup and has been removed as a base requirement for `os2forms_forloeb`.