### PR TITLE
44121: Disable external

### DIFF
--- a/config/optional/webform.webform.disable_external.yml
+++ b/config/optional/webform.webform.disable_external.yml
@@ -8,22 +8,22 @@ dependencies:
 third_party_settings:
   os2forms:
     os2forms_nemid:
-      webform_type: ''
+      webform_type: ""
       nemlogin_auto_redirect: 0
   webform_entity_print:
     template:
-      header: ''
-      footer: ''
-      css: ''
+      header: ""
+      footer: ""
+      css: ""
     export_types:
       pdf:
         enabled: true
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
       word_docx:
         enabled: false
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
 open: null
 close: null
 weight: 0
@@ -31,8 +31,8 @@ uid: 1
 template: false
 archive: false
 id: disable_external
-title: 'Disable External'
-description: 'Disable an external consultant by setting the end date.'
+title: "Disable External"
+description: "Disable an external consultant by setting the end date."
 category: GIR
 elements: |
   search_for_external:
@@ -77,6 +77,7 @@ elements: |
           '#type': date
           '#title': 'Termination Date'
           '#required': true
+          '#default_value': today
           '#date_date_format': ''
       approval_information:
         '#type': fieldset
@@ -97,32 +98,32 @@ elements: |
             include_anonymous: false
             filter:
               type: _none
-css: ''
-javascript: ''
+css: ""
+javascript: ""
 settings:
   ajax: false
   ajax_scroll_top: form
-  ajax_progress_type: ''
-  ajax_effect: ''
+  ajax_progress_type: ""
+  ajax_effect: ""
   ajax_speed: null
   page: true
-  page_submit_path: ''
-  page_confirm_path: ''
-  page_theme_name: ''
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
-  form_open_message: ''
-  form_close_message: ''
+  form_exception_message: ""
+  form_open_message: ""
+  form_close_message: ""
   form_previous_submissions: true
   form_confidential: false
-  form_confidential_message: ''
+  form_confidential_message: ""
   form_remote_addr: true
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
-  form_prepopulate_source_entity_type: ''
+  form_prepopulate_source_entity_type: ""
   form_reset: false
   form_disable_autocomplete: false
   form_novalidate: false
@@ -134,35 +135,35 @@ settings:
   form_autofocus: false
   form_details_toggle: false
   form_access_denied: default
-  form_access_denied_title: ''
-  form_access_denied_message: ''
-  form_access_denied_attributes: {  }
-  form_file_limit: ''
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
   share: false
   share_node: false
-  share_theme_name: ''
+  share_theme_name: ""
   share_title: true
-  share_page_body_attributes: {  }
-  submission_label: ''
+  share_page_body_attributes: {}
+  submission_label: ""
   submission_log: false
-  submission_views: {  }
-  submission_views_replace: {  }
-  submission_user_columns: {  }
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
   submission_user_duplicate: false
   submission_access_denied: default
-  submission_access_denied_title: ''
-  submission_access_denied_message: ''
-  submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_excluded_elements: {}
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
-  previous_submission_message: ''
-  previous_submissions_message: ''
+  previous_submission_message: ""
+  previous_submissions_message: ""
   autofill: false
-  autofill_message: ''
-  autofill_excluded_elements: {  }
+  autofill_message: ""
+  autofill_excluded_elements: {}
   wizard_progress_bar: true
   wizard_progress_pages: false
   wizard_progress_percentage: false
@@ -171,49 +172,49 @@ settings:
   wizard_auto_forward: true
   wizard_auto_forward_hide_next_button: false
   wizard_keyboard: true
-  wizard_start_label: ''
+  wizard_start_label: ""
   wizard_preview_link: false
   wizard_confirmation: true
-  wizard_confirmation_label: ''
-  wizard_track: ''
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
+  wizard_confirmation_label: ""
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
   wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
   preview: 0
-  preview_label: ''
-  preview_title: ''
-  preview_message: ''
-  preview_attributes: {  }
-  preview_excluded_elements: {  }
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
   draft: none
   draft_multiple: false
   draft_auto_save: false
-  draft_saved_message: ''
-  draft_loaded_message: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
   confirmation_type: page
-  confirmation_title: ''
-  confirmation_message: ''
-  confirmation_url: ''
-  confirmation_attributes: {  }
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_url: ""
+  confirmation_attributes: {}
   confirmation_back: true
-  confirmation_back_label: ''
-  confirmation_back_attributes: {  }
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
   confirmation_exclude_query: false
   confirmation_exclude_token: false
   confirmation_update: false
   limit_total: null
   limit_total_interval: null
-  limit_total_message: ''
+  limit_total_message: ""
   limit_total_unique: false
   limit_user: null
   limit_user_interval: null
-  limit_user_message: ''
+  limit_user_message: ""
   limit_user_unique: false
   entity_limit_total: null
   entity_limit_total_interval: null
@@ -233,68 +234,68 @@ access:
     roles:
       - anonymous
       - authenticated
-    users: {  }
-    permissions: {  }
+    users: {}
+    permissions: {}
   view_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   purge_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   view_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   administer:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   test:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   configuration:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
 handlers:
   spawn_maestro_workflow:
     id: maestro
-    label: 'Spawn Maestro Workflow'
-    notes: ''
+    label: "Spawn Maestro Workflow"
+    notes: ""
     handler_id: spawn_maestro_workflow
     status: true
-    conditions: {  }
+    conditions: {}
     weight: 0
     settings:
       maestro_template: disable_external
-      maestro_message_success: ''
-      maestro_message_failure: ''
+      maestro_message_success: ""
+      maestro_message_failure: ""
   load_employee:
     id: employee
-    label: 'Load Employee'
-    notes: ''
+    label: "Load Employee"
+    notes: ""
     handler_id: load_employee
     status: true
-    conditions: {  }
+    conditions: {}
     weight: 0
-    settings: {  }
-variants: {  }
+    settings: {}
+variants: {}

--- a/os2forms_egir.module
+++ b/os2forms_egir.module
@@ -330,19 +330,13 @@ function os2forms_egir_gir_disable_org_unit($processID, $queueID) {
 
   // We terminate *from* end_date *to* infinity.
   // NB: This kind of validity payload is only possible as of MO ^2.0!
-  $validity = ['from' => $end_date, 'to' => NULL];
+  $validity = ['validity' => ['from' => $end_date, 'to' => NULL]];
   $org_unit_uuid = GIRUtils::getTermData($org_unit_id, 'field_uuid');
 
-  $termination_data = [
-    'type' => 'org_unit',
-    'uuid' => $org_unit_uuid,
-    'validity' => $validity,
-  ];
-
-  $json_data = json_encode($termination_data);
+  $json_data = json_encode($validity);
   GIRUtils::formsLog()->notice('Termination data sent: <' . $json_data . '>');
 
-  $resp = GIRUtils::postJsonToApi('/service/details/terminate', $json_data);
+  $resp = GIRUtils::postJsonToApi("/service/ou/{$org_unit_uuid}/terminate", $json_data);
 
   if ($resp->getStatusCode() === 200) {
     $url_status = 'Success';
@@ -365,7 +359,44 @@ function os2forms_egir_gir_disable_org_unit($processID, $queueID) {
  * Disable external.
  */
 function os2forms_egir_gir_disable_external($processID, $queueID) {
-  // @todo Implement this.
+  // Get ID for webform which spawned this process.
+  $sid = MaestroEngine::getEntityIdentiferByUniqueID($processID, 'submission');
+  if ($sid) {
+
+    $webform_submission = WebformSubmission::load($sid);
+    // cf.
+    // https://www.drupal.org/project/webform/issues/2911356#comment-12271553
+    $values = $webform_submission->getData();
+
+    // Termination data.
+    $external_id = $values['external_employee'];
+    $first_name = $values['first_name'];
+    $last_name = $values['last_name'];
+    $end_date = $values['end_date'];
+  }
+  else {
+    return FALSE;
+  }
+  $external_uuid = GIRUtils::getUserData($external_id, 'field_uuid');
+  // Unfortunately, terminating *from* end date *to* infinity is currently
+  // not possible from this endpoint. We use the old way.
+  $validity = ['validity' => ['to' => $end_date]];
+  $json_data = json_encode($validity);
+  $resp = GIRUtils::postJsonToApi("/service/e/{$external_uuid}/terminate", $json_data);
+
+  if ($resp->getStatusCode() === 200) {
+    $url_status = 'Success';
+    $url_body = "External employee {$first_name} {$last_name} was "
+              . 'successfully terminated.';
+  }
+  else {
+    $url_status = 'Failed';
+    $err_msg = json_decode($resp->getBody(), TRUE)['description'] ?? 'No description';
+    $url_body = "Unable to terminate external employee: {$err_msg}";
+  };
+
+  MaestroEngine::setProcessVariable('url_status', $url_status, $processID);
+  MaestroEngine::setProcessVariable('url_body', $url_body, $processID);
   return TRUE;
 }
 


### PR DESCRIPTION
This MR adds the POST requests necessary to terminate Externals in GIR from EGIR.

Note that the endpoint for termination of org units was updated as well, as I realised I was using the wrong one. The webform has been updated with termination date defaulting to `today`.